### PR TITLE
FileUtis.cp_r cannot overwrite a symlink of directory

### DIFF
--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -412,7 +412,7 @@ module FileUtils
   def copy_entry(src, dest, preserve = false, dereference_root = false, remove_destination = false)
     Entry_.new(src, nil, dereference_root).wrap_traverse(proc do |ent|
       destent = Entry_.new(dest, ent.rel, false)
-      File.unlink destent.path if remove_destination && File.file?(destent.path)
+      File.unlink destent.path if remove_destination && (File.file?(destent.path) || File.symlink?(destent.path))
       ent.copy destent.path
     end, proc do |ent|
       destent = Entry_.new(dest, ent.rel, false)

--- a/test/fileutils/test_fileutils.rb
+++ b/test/fileutils/test_fileutils.rb
@@ -438,6 +438,15 @@ class TestFileUtils < Test::Unit::TestCase
     }
   end
 
+  def test_cp_r_symlink_remove_destination
+    Dir.mkdir 'tmp/src'
+    Dir.mkdir 'tmp/dest'
+    Dir.mkdir 'tmp/src/dir'
+    File.symlink 'tmp/src/dir', 'tmp/src/a'
+    cp_r 'tmp/src', 'tmp/dest/', remove_destination: true
+    cp_r 'tmp/src', 'tmp/dest/', remove_destination: true
+  end
+
   def test_mv
     check_singleton :mv
 
@@ -1437,6 +1446,14 @@ class TestFileUtils < Test::Unit::TestCase
     assert_symlink 'tmp/dirdest/sym'
     assert_equal 'somewhere', File.readlink('tmp/dirdest/sym')
   end if have_symlink?
+
+  def test_copy_entry_symlink_remove_destination
+    Dir.mkdir 'tmp/dir'
+    File.symlink 'tmp/dir', 'tmp/dest'
+    touch 'tmp/src'
+    copy_entry 'tmp/src', 'tmp/dest', false, false, true
+    assert_file_exist 'tmp/dest'
+  end
 
   def test_copy_file
     check_singleton :copy_file


### PR DESCRIPTION
`FileUtis.cp_r` with `remove_destination` cannot overwrite a symlink.  Though comment of `cp_r` doesn't provide a detail of this flag, it is good to remove destination symlink file to follow its name.

This problem is same as [Bug #13914](https://bugs.ruby-lang.org/issues/13914).

## Reproduce code

```ruby
require 'fileutils'
# setup directory like following:
#
#   tmp
#   ├── dest
#   └── src
#       ├── a -> dir
#           └── dir
#
FileUtils.rm_rf 'tmp'
%w(tmp/src tmp/dest tmp/src/dir).each do|path|
  FileUtils.mkdir_p path
end
File.symlink 'dir', 'tmp/src/a'

# copy dual
FileUtils.cp_r 'tmp/src', 'tmp/dest/', remove_destination: true
FileUtils.cp_r 'tmp/src', 'tmp/dest/', remove_destination: true # <- Errno::EEXIST exception is raised
```

## Actual behavior

```ruby
$ ruby bug.rb
Traceback (most recent call last):
        13: from bug.rb:18:in `<main>'
        12: from /usr/local/lib/ruby/2.5.0/fileutils.rb:390:in `cp_r'
        11: from /usr/local/lib/ruby/2.5.0/fileutils.rb:1459:in `fu_each_src_dest'
        10: from /usr/local/lib/ruby/2.5.0/fileutils.rb:1475:in `fu_each_src_dest0'
         9: from /usr/local/lib/ruby/2.5.0/fileutils.rb:1461:in `block in fu_each_src_dest'
         8: from /usr/local/lib/ruby/2.5.0/fileutils.rb:391:in `block in cp_r'
         7: from /usr/local/lib/ruby/2.5.0/fileutils.rb:413:in `copy_entry'
         6: from /usr/local/lib/ruby/2.5.0/fileutils.rb:1390:in `wrap_traverse'
         5: from /usr/local/lib/ruby/2.5.0/fileutils.rb:1390:in `each'
         4: from /usr/local/lib/ruby/2.5.0/fileutils.rb:1391:in `block in wrap_traverse'
         3: from /usr/local/lib/ruby/2.5.0/fileutils.rb:1388:in `wrap_traverse'
         2: from /usr/local/lib/ruby/2.5.0/fileutils.rb:416:in `block in copy_entry'
         1: from /usr/local/lib/ruby/2.5.0/fileutils.rb:1268:in `copy'
/usr/local/lib/ruby/2.5.0/fileutils.rb:1268:in `symlink': File exists @ syserr_fail2_in - tmp/dest/src/a (Errno::EEXIST)
```

## Except behavior
This exception should not happen, and tmp/src is copied in a tmp/dest.

## Environment
I met this problem at Ruby 2.4.2 on macOS HighSierra and 2.5.0-preview1 on alpine linux.

I use [this Dockerfile](https://gist.github.com/mzp/fe24a7135ecfbc2f611c2f8190962a18) to test this PR.

## Affect of this
Fastlane, major macOS/iOS/Android build tool, is affected by this problem. (https://github.com/fastlane/fastlane/issues/9537)