### PR TITLE
Fix documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ FileUtils.pwd
 # => "/usr/bin"
 ```
 
-You can find a full method list in the [documentation](https://ruby-doc.org/stdlib-1.9.3/libdoc/fileutils/rdoc/FileUtils.html).
+You can find a full method list in the [documentation](https://ruby-doc.org/stdlib/libdoc/fileutils/rdoc/FileUtils.html).
 
 ## Contributing
 


### PR DESCRIPTION
Provide an unversioned link that always
points to the docs for the latest Ruby.

_[I missed this in my last PR.]_

Alternatives to https://ruby-doc.org/stdlib/libdoc/fileutils/rdoc/FileUtils.html (latest stable release) would be:

* https://docs.ruby-lang.org/en/trunk/FileUtils.html (Ruby trunk docs, daily build)
* http://www.rubydoc.info/gems/fileutils/FileUtils (latest gem release docs)

(ruby-doc.org also has a `stdlib-trunk` branch, but I'm not sure whether this is kept up-to-date.)

If you prefer one of those, I can amend the PR.