### PR TITLE
Add FileUtils::VERSION

### DIFF
--- a/fileutils.gemspec
+++ b/fileutils.gemspec
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'fileutils/version'
+
 Gem::Specification.new do |s|
   s.name = "fileutils"
-  s.version = '0.7.2'
+  s.version = FileUtils::VERSION
   s.date = '2017-02-06'
   s.summary = "Several file utility methods for copying, moving, removing, etc."
   s.description = "Several file utility methods for copying, moving, removing, etc."

--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -85,6 +85,8 @@
 # <tt>:verbose</tt> flags to methods in FileUtils.
 #
 
+require 'fileutils/version'
+
 module FileUtils
 
   def self.private_module_function(name)   #:nodoc:

--- a/lib/fileutils/version.rb
+++ b/lib/fileutils/version.rb
@@ -1,0 +1,3 @@
+module FileUtils
+  VERSION = '0.7.3.beta1'
+end


### PR DESCRIPTION
Hello,
I want to add `FileUtils::VERSION`.

Because `bundler` is bundling `fileutils` internally. And I want to know the file's original version casually.
https://github.com/bundler/bundler/blob/master/lib/bundler/vendor/fileutils/lib/fileutils.rb

I tested below things on latest trunk's Ruby.

```
$ ruby -v
ruby 2.5.0dev (2017-11-09 trunk 60727) [x86_64-linux]

$ ruby -Ilib -r fileutils -e 'puts FileUtils::VERSION'
0.7.3-dev

$ gem --version
2.7.2

$ which gem
/home/jaruga/git/ruby/dest/bin/gem

$ gem build fileutils.gemspec
WARNING:  description and summary are identical
WARNING:  open-ended dependency on rake (>= 0, development) is not recommended
  if rake is semantically versioned, use:
    add_development_dependency 'rake', '~> 0'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: fileutils
  Version: 0.7.3.pre.dev
  File: fileutils-0.7.3.pre.dev.gem
```

I referred `did_you_mean` for the implementation of `FileUtils::VERSION`.
https://github.com/yuki24/did_you_mean/blob/master/did_you_mean.gemspec

