### PR TITLE
FileUtils.cd now returns result of block, if given

### DIFF
--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -117,8 +117,9 @@ module FileUtils
   #
   def cd(dir, verbose: nil, &block) # :yield: dir
     fu_output_message "cd #{dir}" if verbose
-    Dir.chdir(dir, &block)
+    result = Dir.chdir(dir, &block)
     fu_output_message 'cd -' if verbose and block
+    result
   end
   module_function :cd
 

--- a/test/fileutils/test_fileutils.rb
+++ b/test/fileutils/test_fileutils.rb
@@ -1573,6 +1573,10 @@ class TestFileUtils < Test::Unit::TestCase
     check_singleton :cd
   end
 
+  def test_cd_result
+    assert_equal 42, cd('.') { 42 }
+  end
+
   def test_chdir
     check_singleton :chdir
   end


### PR DESCRIPTION
Contrary to `Dir.chdir`, `FileUtils.chdir` ignores the result of the block.

This fixes it.

Should this be committed to MRI's trunk, or here?