### PR TITLE
Use FileUtils::VERSION in gemspec

### DIFF
--- a/fileutils.gemspec
+++ b/fileutils.gemspec
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
+
+require_relative "lib/fileutils"
+
 Gem::Specification.new do |s|
   s.name = "fileutils"
-  s.version = '1.0.2'
+  s.version = FileUtils::VERSION
   s.date = '2017-12-22'
   s.summary = "Several file utility methods for copying, moving, removing, etc."
   s.description = "Several file utility methods for copying, moving, removing, etc."


### PR DESCRIPTION
[WIP]

Use already defined constant instead of duplicating the information.
I‘m pretty sure the gem version and library version would soon diverge otherwise.

But: requiring fileutils in the gemspec causes „already initialized constant“ warnings, because bundler requires fileutils, too. This could be solved by a separate file with only the version info (like it is often done in other gems).