### PR TITLE
JRuby tweaks

### DIFF
--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -85,6 +85,8 @@
 # <tt>:verbose</tt> flags to methods in FileUtils.
 #
 
+require 'rbconfig'
+
 module FileUtils
 
   VERSION = "1.0.2"

--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -488,7 +488,7 @@ module FileUtils
   module_function :move
 
   def rename_cannot_overwrite_file?   #:nodoc:
-    /emx/ =~ RUBY_PLATFORM
+    /emx/ =~ RbConfig::CONFIG['host_os']
   end
   private_module_function :rename_cannot_overwrite_file?
 
@@ -1070,7 +1070,7 @@ module FileUtils
     private
 
     def fu_windows?
-      /mswin|mingw|bccwin|emx/ =~ RUBY_PLATFORM
+      /mswin|mingw|bccwin|emx/ =~ RbConfig::CONFIG['host_os']
     end
 
     def fu_copy_stream0(src, dest, blksize = nil)   #:nodoc:


### PR DESCRIPTION
There's two changes here, one to use rbconfig instead of RUBY_PLATFORM to detect host operating system, and the remove_entry_secure changes relating to opening a dir as a file (mentioned in #17).

These are the only diffs that JRuby has from MRI's stdlib fileutils.rb. If these are incorporated into the fileutils gem, we can eliminate our copy.