### PR TITLE
Extend timeout second for test_assert_output_lines with JRuby

### DIFF
--- a/test/fileutils/test_fileutils.rb
+++ b/test/fileutils/test_fileutils.rb
@@ -233,7 +233,7 @@ class TestFileUtils < Test::Unit::TestCase
 
   def test_assert_output_lines
     assert_raise(MiniTest::Assertion) {
-      Timeout.timeout(0.1) {
+      Timeout.timeout(0.5) {
         assert_output_lines([]) {
           Thread.current.report_on_exception = false
           raise "ok"


### PR DESCRIPTION
Maybe fixes https://travis-ci.org/ruby/fileutils/jobs/378545293