### PR TITLE
Add missing `remove_destination` option to a doc [ci skip]

### DIFF
--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -56,7 +56,7 @@
 #
 # There are some `low level' methods, which do not accept any option:
 #
-#   FileUtils.copy_entry(src, dest, preserve = false, dereference = false)
+#   FileUtils.copy_entry(src, dest, preserve = false, dereference_root = false, remove_destination = false)
 #   FileUtils.copy_file(src, dest, preserve = false, dereference = true)
 #   FileUtils.copy_stream(srcstream, deststream)
 #   FileUtils.remove_entry(path, force = false)


### PR DESCRIPTION
Also, fixed the argument name to be the same as the actual argument name.
Ref: https://github.com/ruby/fileutils/blob/64e2750f095524f89df16c8ac5981207f9a4d9f2/lib/fileutils.rb#L474