### PR TITLE
Use FileUtils::VERSION in gemspec

### DIFF
--- a/fileutils.gemspec
+++ b/fileutils.gemspec
@@ -1,13 +1,20 @@
 # frozen_string_literal: true
 
+begin
+  require_relative "lib/fileutils/version"
+rescue LoadError
+  # for Ruby core repository
+  require_relative "version"
+end
+
 Gem::Specification.new do |s|
   s.name = "fileutils"
-  s.version = '1.1.0'
+  s.version = FileUtils::VERSION
   s.summary = "Several file utility methods for copying, moving, removing, etc."
   s.description = "Several file utility methods for copying, moving, removing, etc."
 
   s.require_path = %w{lib}
-  s.files = [".gitignore", ".travis.yml", "Gemfile", "LICENSE.txt", "README.md", "Rakefile", "bin/console", "bin/setup", "fileutils.gemspec", "lib/fileutils.rb"]
+  s.files = [".gitignore", ".travis.yml", "Gemfile", "LICENSE.txt", "README.md", "Rakefile", "bin/console", "bin/setup", "fileutils.gemspec", "lib/fileutils.rb", "lib/fileutils/version.rb"]
   s.required_ruby_version = ">= 2.3.0"
 
   s.authors = ["Minero Aoki"]

--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -91,9 +91,9 @@ rescue LoadError
   # for make mjit-headers
 end
 
-module FileUtils
+require "fileutils/version"
 
-  VERSION = "1.1.0"
+module FileUtils
 
   def self.private_module_function(name)   #:nodoc:
     module_function name

--- a/lib/fileutils/version.rb
+++ b/lib/fileutils/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module FileUtils
+  VERSION = "1.1.0"
+end


### PR DESCRIPTION
_Replaces #15._

Use already defined constant FileUtils::VERSION instead of duplicating
the information. Also move FileUtils::VERSION into its own file.

I moved FileUtils::VERSION into its own file to reduce warnings about already defined constants that happened with `gem build`.

In the gemspec, the require statement for the ruby core repository assumes that the gemfile and `version.rb` are in the same directory (same structure as e.g. for `thwait`).

**Please do not yet merge**, but update first to the latest core repository version of fileutils; this will probably cause a merge conflict and again break what I fixed in r64911; I will then fix the commit as necessary and repush the branch.

@hsbt