### PR TITLE
Remove development files in gem releases

### DIFF
--- a/fileutils.gemspec
+++ b/fileutils.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.description = "Several file utility methods for copying, moving, removing, etc."
 
   s.require_path = %w{lib}
-  s.files = [".gitignore", ".travis.yml", "Gemfile", "LICENSE.txt", "README.md", "Rakefile", "bin/console", "bin/setup", "fileutils.gemspec", "lib/fileutils.rb", "lib/fileutils/version.rb"]
+  s.files = ["LICENSE.txt", "README.md", "Rakefile", "fileutils.gemspec", "lib/fileutils.rb", "lib/fileutils/version.rb"]
   s.required_ruby_version = ">= 2.3.0"
 
   s.authors = ["Minero Aoki"]


### PR DESCRIPTION
This PR is pretty much the same as https://github.com/ruby/logger/pull/7. There are some files like `.travis.yml` which do not need to be included in gem releases.