### PR TITLE
fix breaking specs in CI due to undefined method in ruby MRI < 2.5

### DIFF
--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -1274,8 +1274,15 @@ module FileUtils
     def entries
       opts = {}
       opts[:encoding] = ::Encoding::UTF_8 if fu_windows?
-      Dir.children(path, opts)\
-          .map {|n| Entry_.new(prefix(), join(rel(), n.untaint)) }
+
+      files = if Dir.respond_to?(:children)
+        Dir.children(path, opts)
+      else
+        Dir.entries(path(), opts)
+           .reject {|n| n == '.' or n == '..' }
+      end
+
+      files.map {|n| Entry_.new(prefix(), join(rel(), n.untaint)) }
     end
 
     def stat


### PR DESCRIPTION
`Dir.children` is only available on versions of MRI >= 2.5. This is breaking CI and preventing new PRs from being merged. This was caused by https://github.com/ruby/fileutils/commit/d8c665c564e5d4e54da1c92788613f524aad0de2

This PR fixes the issue by checking if the method exists, otherwise, use the previous way of getting filenames.