### PR TITLE
Link documentation to rubydoc.info

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ FileUtils.pwd
 # => "/usr/bin"
 ```
 
-You can find a full method list in the [documentation](https://ruby-doc.org/stdlib/libdoc/fileutils/rdoc/FileUtils.html).
+You can find a full method list in the [documentation](https://www.rubydoc.info/github/ruby/fileutils/master/FileUtils).
 
 ## Contributing
 


### PR DESCRIPTION
This PR updates the documentation that is linked in the README from ruby-doc.org to rubydoc.info. This gives the advantage of when documentation is committed to the `master` branch, it will automatically be updated.