### PR TITLE
Lazily require `etc`

### DIFF
--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -1081,11 +1081,6 @@ module FileUtils
   end
   module_function :chown_R
 
-  begin
-    require 'etc'
-  rescue LoadError # rescue LoadError for miniruby
-  end
-
   def fu_get_uid(user)   #:nodoc:
     return nil unless user
     case user
@@ -1094,6 +1089,7 @@ module FileUtils
     when /\A\d+\z/
       user.to_i
     else
+      require 'etc'
       Etc.getpwnam(user) ? Etc.getpwnam(user).uid : nil
     end
   end
@@ -1107,6 +1103,7 @@ module FileUtils
     when /\A\d+\z/
       group.to_i
     else
+      require 'etc'
       Etc.getgrnam(group) ? Etc.getgrnam(group).gid : nil
     end
   end


### PR DESCRIPTION
This helps `bundler` by not activating the `etc` gem automatically when it's vendored version of `fileutils` is required. That would allow `bundler` users to activate any version of the `etc` gem they want.