### PR TITLE
Require version file relatively

### DIFF
--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -6,7 +6,7 @@ rescue LoadError
   # for make mjit-headers
 end
 
-require "fileutils/version"
+require_relative "fileutils/version"
 
 #
 # = fileutils.rb


### PR DESCRIPTION
This avoids searching the LOAD_PATH and it also helps `bundler` when vendoring this gem because it won't need to do any [modifications to the way it's required](https://github.com/bundler/bundler/blob/dd8e145596da7a9c93f11f42ce9196f591a3a6c8/lib/bundler/vendor/fileutils/lib/fileutils.rb#L9).