### PR TITLE
Make copy methods handle FIFOs and UNIX sockets

### DIFF
--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -1369,18 +1369,21 @@ module FileUtils
         end
       when symlink?
         File.symlink File.readlink(path()), dest
-      when chardev?
-        raise "cannot handle device file" unless File.respond_to?(:mknod)
-        mknod dest, ?c, 0666, lstat().rdev
-      when blockdev?
-        raise "cannot handle device file" unless File.respond_to?(:mknod)
-        mknod dest, ?b, 0666, lstat().rdev
+      when chardev?, blockdev?
+        raise "cannot handle device file"
       when socket?
-        raise "cannot handle socket" unless File.respond_to?(:mknod)
-        mknod dest, nil, lstat().mode, 0
+        begin
+          require 'socket'
+        rescue LoadError
+          raise "cannot handle socket"
+        else
+          raise "cannot handle socket" unless defined?(UNIXServer)
+        end
+        UNIXServer.new(dest).close
+        File.chmod lstat().mode, dest
       when pipe?
         raise "cannot handle FIFO" unless File.respond_to?(:mkfifo)
-        mkfifo dest, 0666
+        File.mkfifo dest, lstat().mode
       when door?
         raise "cannot handle door: #{path()}"
       else

--- a/test/fileutils/test_fileutils.rb
+++ b/test/fileutils/test_fileutils.rb
@@ -451,6 +451,7 @@ class TestFileUtils < Test::Unit::TestCase
   rescue LoadError
   else
     def test_cp_r_socket
+      skip "Skipping socket test on JRuby" if RUBY_ENGINE == 'jruby'
       Dir.mkdir('tmp/cpr_src')
       UNIXServer.new('tmp/cpr_src/socket').close
       cp_r 'tmp/cpr_src', 'tmp/cpr_dest'

--- a/test/fileutils/test_fileutils.rb
+++ b/test/fileutils/test_fileutils.rb
@@ -430,6 +430,34 @@ class TestFileUtils < Test::Unit::TestCase
     }
   end if have_symlink? and !no_broken_symlink?
 
+  def test_cp_r_fifo
+    Dir.mkdir('tmp/cpr_src')
+    File.mkfifo 'tmp/cpr_src/fifo', 0600
+    cp_r 'tmp/cpr_src', 'tmp/cpr_dest'
+    assert_equal(true, File.pipe?('tmp/cpr_dest/fifo'))
+  end if File.respond_to?(:mkfifo)
+
+  def test_cp_r_dev
+    devs = Dir['/dev/*']
+    chardev = Dir['/dev/*'].find{|f| File.chardev?(f)}
+    blockdev = Dir['/dev/*'].find{|f| File.blockdev?(f)}
+    Dir.mkdir('tmp/cpr_dest')
+    assert_raise(RuntimeError) { cp_r chardev, 'tmp/cpr_dest/cd' }
+    assert_raise(RuntimeError) { cp_r blockdev, 'tmp/cpr_dest/bd' }
+  end
+
+  begin
+    require 'socket'
+  rescue LoadError
+  else
+    def test_cp_r_socket
+      Dir.mkdir('tmp/cpr_src')
+      UNIXServer.new('tmp/cpr_src/socket').close
+      cp_r 'tmp/cpr_src', 'tmp/cpr_dest'
+      assert_equal(true, File.socket?('tmp/cpr_dest/socket'))
+    end if defined?(UNIXServer)
+  end
+
   def test_cp_r_pathname
     # pathname
     touch 'tmp/cprtmp'


### PR DESCRIPTION
Previously, this was broken.  Trying to copy a FIFO would raise a
NoMethodError if File.mkfifo was defined.  Trying to copy a UNIX
socket would raise a RuntimeError as File.mknod is not something
Ruby defines.

Handle the FIFO issue using File.mkfifo instead of mkfifo.

Handle the UNIX Socket issue by creating a unix socket.

Continue to not support character or block devices, raising a
RuntimeError for both.

Add tests for FIFO, UNIX Socket, and character/block devices.

Fixes Ruby Bug 10104.