### PR TITLE
Do not break in verbose mode if using FileUtils with a frozen object

### DIFF
--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -1602,13 +1602,13 @@ module FileUtils
   end
   private_module_function :fu_same?
 
-  @fileutils_output = $stderr
-  @fileutils_label  = ''
-
   def fu_output_message(msg)   #:nodoc:
-    @fileutils_output ||= $stderr
-    @fileutils_label  ||= ''
-    @fileutils_output.puts @fileutils_label + msg
+    output = @fileutils_output if defined?(@fileutils_output)
+    output ||= $stderr
+    if defined?(@fileutils_label)
+      msg = @fileutils_label + msg
+    end
+    output.puts msg
   end
   private_module_function :fu_output_message
 
@@ -1689,8 +1689,6 @@ module FileUtils
   #
   module Verbose
     include FileUtils
-    @fileutils_output  = $stderr
-    @fileutils_label   = ''
     names = ::FileUtils.collect_method(:verbose)
     names.each do |name|
       module_eval(<<-EOS, __FILE__, __LINE__ + 1)
@@ -1714,8 +1712,6 @@ module FileUtils
   module NoWrite
     include FileUtils
     include LowMethods
-    @fileutils_output  = $stderr
-    @fileutils_label   = ''
     names = ::FileUtils.collect_method(:noop)
     names.each do |name|
       module_eval(<<-EOS, __FILE__, __LINE__ + 1)
@@ -1740,8 +1736,6 @@ module FileUtils
   module DryRun
     include FileUtils
     include LowMethods
-    @fileutils_output  = $stderr
-    @fileutils_label   = ''
     names = ::FileUtils.collect_method(:noop)
     names.each do |name|
       module_eval(<<-EOS, __FILE__, __LINE__ + 1)

--- a/test/fileutils/test_fileutils.rb
+++ b/test/fileutils/test_fileutils.rb
@@ -6,6 +6,7 @@ require 'etc'
 require_relative 'fileasserts'
 require 'pathname'
 require 'tmpdir'
+require 'stringio'
 require 'test/unit'
 
 class TestFileUtils < Test::Unit::TestCase
@@ -1632,6 +1633,29 @@ class TestFileUtils < Test::Unit::TestCase
 
   def test_chdir
     check_singleton :chdir
+  end
+
+  def test_chdir_verbose
+    assert_output_lines(["cd .", "cd -"], FileUtils) do
+      FileUtils.chdir('.', verbose: true){}
+    end
+  end
+
+  def test_chdir_verbose_frozen
+    o = Object.new
+    o.extend(FileUtils)
+    o.singleton_class.send(:public, :chdir)
+    o.freeze
+    orig_stderr = $stderr
+    $stderr = StringIO.new
+    o.chdir('.', verbose: true){}
+    $stderr.rewind
+    assert_equal(<<-END, $stderr.read)
+cd .
+cd -
+    END
+  ensure
+    $stderr = orig_stderr if orig_stderr
   end
 
   def test_getwd


### PR DESCRIPTION
If FileUtils is included into another object, and verbose mode is
used, a FrozenError is currently raised unless the object has the
@fileutils_output and @fileutils_label instance variables.

This fixes things so that it does not attempt to set the instance
variables, but it still uses them if they are present.