### PR TITLE
Fix a Couple Windows Issues

### DIFF
--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -488,7 +488,11 @@ module FileUtils
   # If +remove_destination+ is true, this method removes each destination file before copy.
   #
   def copy_entry(src, dest, preserve = false, dereference_root = false, remove_destination = false)
-    Entry_.new(src, nil, dereference_root).wrap_traverse(proc do |ent|
+    if dereference_root
+      src = File.realpath(src)
+    end
+
+    Entry_.new(src, nil, false).wrap_traverse(proc do |ent|
       destent = Entry_.new(dest, ent.rel, false)
       File.unlink destent.path if remove_destination && (File.file?(destent.path) || File.symlink?(destent.path))
       ent.copy destent.path

--- a/test/fileutils/test_fileutils.rb
+++ b/test/fileutils/test_fileutils.rb
@@ -449,11 +449,11 @@ class TestFileUtils < Test::Unit::TestCase
 
   def test_cp_r_dev
     devs = Dir['/dev/*']
-    chardev = Dir['/dev/*'].find{|f| File.chardev?(f)}
-    blockdev = Dir['/dev/*'].find{|f| File.blockdev?(f)}
+    chardev = devs.find{|f| File.chardev?(f)}
+    blockdev = devs.find{|f| File.blockdev?(f)}
     Dir.mkdir('tmp/cpr_dest')
-    assert_raise(RuntimeError) { cp_r chardev, 'tmp/cpr_dest/cd' }
-    assert_raise(RuntimeError) { cp_r blockdev, 'tmp/cpr_dest/bd' }
+    assert_raise(RuntimeError) { cp_r chardev, 'tmp/cpr_dest/cd' } if chardev
+    assert_raise(RuntimeError) { cp_r blockdev, 'tmp/cpr_dest/bd' } if blockdev
   end
 
   begin


### PR DESCRIPTION
Fix cp_r with symlink root on Windows

Previously this would copy the symlink root as a symlink instead
of creating a new root directory.  This modifies the source
to expand it using File.realpath before starting the copy.

Fix test_cp_r_dev on Windows or other systems without
character/block device in /dev

Fixes Ruby Bug 12123