### PR TITLE
Remove version.rb

### DIFF
--- a/fileutils.gemspec
+++ b/fileutils.gemspec
@@ -1,20 +1,23 @@
 # frozen_string_literal: true
 
-begin
-  require_relative "lib/fileutils/version"
-rescue LoadError
-  # for Ruby core repository
-  require_relative "version"
+source_version = ["", "lib/"].find do |dir|
+  begin
+    break File.open(File.join(__dir__, "#{dir}fileutils.rb")) {|f|
+      f.gets("\n  VERSION = ")
+      f.gets[/\s*"(.+)"/, 1]
+    }
+  rescue Errno::ENOENT
+  end
 end
 
 Gem::Specification.new do |s|
   s.name = "fileutils"
-  s.version = FileUtils::VERSION
+  s.version = source_version
   s.summary = "Several file utility methods for copying, moving, removing, etc."
   s.description = "Several file utility methods for copying, moving, removing, etc."
 
   s.require_path = %w{lib}
-  s.files = ["LICENSE.txt", "README.md", "Rakefile", "fileutils.gemspec", "lib/fileutils.rb", "lib/fileutils/version.rb"]
+  s.files = ["LICENSE.txt", "README.md", "Rakefile", "fileutils.gemspec", "lib/fileutils.rb"]
   s.required_ruby_version = ">= 2.3.0"
 
   s.authors = ["Minero Aoki"]
@@ -22,9 +25,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/ruby/fileutils"
   s.license = "BSD-2-Clause"
 
-  if s.respond_to?(:metadata=)
-    s.metadata = {
-      "source_code_uri" => "https://github.com/ruby/fileutils"
-    }
-  end
+  s.metadata = {
+    "source_code_uri" => "https://github.com/ruby/fileutils"
+  }
 end

--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -6,8 +6,6 @@ rescue LoadError
   # for make mjit-headers
 end
 
-require_relative "fileutils/version"
-
 #
 # = fileutils.rb
 #
@@ -104,6 +102,7 @@ require_relative "fileutils/version"
 # <tt>:verbose</tt> flags to methods in FileUtils.
 #
 module FileUtils
+  VERSION = "1.3.0"
 
   def self.private_module_function(name)   #:nodoc:
     module_function name

--- a/lib/fileutils/version.rb
+++ b/lib/fileutils/version.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-module FileUtils
-  VERSION = "1.3.0"
-end


### PR DESCRIPTION
Loading separate version.rb unnecessary increases every start-up time.  In the other hand, the gemspec file is parsed only when building the gem file.