### PR TITLE
Fix `#install` with "X" mode option

### DIFF
--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -918,11 +918,8 @@ module FileUtils
   private_module_function :apply_mask
 
   def symbolic_modes_to_i(mode_sym, path)  #:nodoc:
-    mode = if File::Stat === path
-             path.mode
-           else
-             File.stat(path).mode
-           end
+    path = File.stat(path) unless File::Stat === path
+    mode = path.mode
     mode_sym.split(/,/).inject(mode & 07777) do |current_mode, clause|
       target, *actions = clause.split(/([=+-])/)
       raise ArgumentError, "invalid file mode: #{mode_sym}" if actions.empty?
@@ -939,7 +936,7 @@ module FileUtils
           when "x"
             mask | 0111
           when "X"
-            if FileTest.directory? path
+            if path.directory?
               mask | 0111
             else
               mask

--- a/test/fileutils/test_fileutils.rb
+++ b/test/fileutils/test_fileutils.rb
@@ -1160,6 +1160,30 @@ class TestFileUtils < Test::Unit::TestCase
     }
   end
 
+  def test_install_mode_option
+    File.open('tmp/a', 'w') {|f| f.puts 'aaa' }
+    install 'tmp/a', 'tmp/b', :mode => "u=wrx,g=rx,o=x"
+    assert_filemode 0751, 'tmp/b'
+    install 'tmp/b', 'tmp/c', :mode => "g+w-x"
+    assert_filemode 0761, 'tmp/c'
+    install 'tmp/c', 'tmp/d', :mode => "o+r,g=o+w,o-r,u-o" # 761 => 763 => 773 => 771 => 671
+    assert_filemode 0671, 'tmp/d'
+    install 'tmp/d', 'tmp/e', :mode => "go=u"
+    assert_filemode 0666, 'tmp/e'
+    install 'tmp/e', 'tmp/f', :mode => "u=wrx,g=,o="
+    assert_filemode 0700, 'tmp/f'
+    install 'tmp/f', 'tmp/g', :mode => "u=rx,go="
+    assert_filemode 0500, 'tmp/g'
+    install 'tmp/g', 'tmp/h', :mode => "+wrx"
+    assert_filemode 0777, 'tmp/h'
+    install 'tmp/h', 'tmp/i', :mode => "u+s,o=s"
+    assert_filemode 04770, 'tmp/i'
+    install 'tmp/i', 'tmp/j', :mode => "u-w,go-wrx"
+    assert_filemode 04500, 'tmp/j'
+    install 'tmp/j', 'tmp/k', :mode => "+s"
+    assert_filemode 06500, 'tmp/k'
+  end if have_file_perm?
+
   def test_chmod
     check_singleton :chmod
 

--- a/test/fileutils/test_fileutils.rb
+++ b/test/fileutils/test_fileutils.rb
@@ -1182,6 +1182,8 @@ class TestFileUtils < Test::Unit::TestCase
     assert_filemode 04500, 'tmp/j'
     install 'tmp/j', 'tmp/k', :mode => "+s"
     assert_filemode 06500, 'tmp/k'
+    install 'tmp/a', 'tmp/l', :mode => "o+X"
+    assert_filemode 0644, 'tmp/l'
   end if have_file_perm?
 
   def test_chmod


### PR DESCRIPTION
`FileUtils#install` methed raises an unexpected `TypeError`, when called with `mode:` option which has `"X"`.

```
$ ruby -rfileutils -e 'FileUtils.install("tmp/a", "tmp/b", mode: "o+X")'
/opt/local/lib/ruby/2.7.0/fileutils.rb:942:in `directory?': no implicit conversion of File::Stat into String (TypeError)
	from /opt/local/lib/ruby/2.7.0/fileutils.rb:942:in `block (3 levels) in symbolic_modes_to_i'
	from /opt/local/lib/ruby/2.7.0/fileutils.rb:933:in `each_char'
	from /opt/local/lib/ruby/2.7.0/fileutils.rb:933:in `each'
	from /opt/local/lib/ruby/2.7.0/fileutils.rb:933:in `inject'
	from /opt/local/lib/ruby/2.7.0/fileutils.rb:933:in `block (2 levels) in symbolic_modes_to_i'
	from /opt/local/lib/ruby/2.7.0/fileutils.rb:931:in `each'
	from /opt/local/lib/ruby/2.7.0/fileutils.rb:931:in `each_slice'
	from /opt/local/lib/ruby/2.7.0/fileutils.rb:931:in `block in symbolic_modes_to_i'
	from /opt/local/lib/ruby/2.7.0/fileutils.rb:926:in `each'
	from /opt/local/lib/ruby/2.7.0/fileutils.rb:926:in `inject'
	from /opt/local/lib/ruby/2.7.0/fileutils.rb:926:in `symbolic_modes_to_i'
	from /opt/local/lib/ruby/2.7.0/fileutils.rb:973:in `fu_mode'
	from /opt/local/lib/ruby/2.7.0/fileutils.rb:883:in `block in install'
	from /opt/local/lib/ruby/2.7.0/fileutils.rb:1588:in `block in fu_each_src_dest'
	from /opt/local/lib/ruby/2.7.0/fileutils.rb:1604:in `fu_each_src_dest0'
	from /opt/local/lib/ruby/2.7.0/fileutils.rb:1586:in `fu_each_src_dest'
	from /opt/local/lib/ruby/2.7.0/fileutils.rb:877:in `install'
	from -e:1:in `<main>'
```

In spite of that `symbolic_modes_to_i` considers the `File::Stat` `path` case at the beginning, in `"X"` case, `path` is passed to `FileTest.directory?` method which requires a `String`.  In such case, the mode in `path` should be examined instead.
