### PR TITLE
Remove use of taint, to avoid deprecation warnings in Ruby 2.7

### DIFF
--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -1300,7 +1300,8 @@ module FileUtils
            .reject {|n| n == '.' or n == '..' }
       end
 
-      files.map {|n| Entry_.new(prefix(), join(rel(), n.untaint)) }
+      untaint = RUBY_VERSION < '2.7'
+      files.map {|n| Entry_.new(prefix(), join(rel(), untaint ? n.untaint : n)) }
     end
 
     def stat


### PR DESCRIPTION
Bump required_ruby_version so older ruby versions that may
depend on taint setting will not be affected.