### PR TITLE
Make verbose output go to stdout instead of stderr

### DIFF
--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -1614,7 +1614,7 @@ module FileUtils
 
   def fu_output_message(msg)   #:nodoc:
     output = @fileutils_output if defined?(@fileutils_output)
-    output ||= $stderr
+    output ||= $stdout
     if defined?(@fileutils_label)
       msg = @fileutils_label + msg
     end

--- a/test/fileutils/test_fileutils.rb
+++ b/test/fileutils/test_fileutils.rb
@@ -1709,16 +1709,16 @@ class TestFileUtils < Test::Unit::TestCase
     o.extend(FileUtils)
     o.singleton_class.send(:public, :chdir)
     o.freeze
-    orig_stderr = $stderr
-    $stderr = StringIO.new
+    orig_stdout = $stdout
+    $stdout = StringIO.new
     o.chdir('.', verbose: true){}
-    $stderr.rewind
-    assert_equal(<<-END, $stderr.read)
+    $stdout.rewind
+    assert_equal(<<-END, $stdout.read)
 cd .
 cd -
     END
   ensure
-    $stderr = orig_stderr if orig_stderr
+    $stdout = orig_stdout if orig_stdout
   end
 
   def test_getwd


### PR DESCRIPTION
Verbose output is not error output, and should be sent to
stdout and not stderr.

Fixes Ruby bug 4436