### PR TITLE
Fix `FileUtils.rm_rf` to only mask exceptions about non existent files

### DIFF
--- a/test/fileutils/test_fileutils.rb
+++ b/test/fileutils/test_fileutils.rb
@@ -1790,7 +1790,7 @@ cd -
     return if /mswin|mingw/ =~ RUBY_PLATFORM
 
     mkdir 'tmpdatadir'
-    chmod 700, 'tmpdatadir'
+    chmod 0700, 'tmpdatadir'
     rm_rf 'tmpdatadir'
 
     assert_file_not_exist 'tmpdatadir'

--- a/test/fileutils/test_fileutils.rb
+++ b/test/fileutils/test_fileutils.rb
@@ -1796,6 +1796,26 @@ cd -
     assert_file_not_exist 'tmpdatadir'
   end
 
+  def test_rm_rf_no_permissions
+    check_singleton :rm_rf
+
+    return if /mswin|mingw/ =~ RUBY_PLATFORM
+
+    mkdir 'tmpdatadir'
+    touch 'tmpdatadir/tmpdata'
+    chmod "-x", 'tmpdatadir'
+
+    begin
+      assert_raise Errno::EACCES do
+        rm_rf 'tmpdatadir'
+      end
+
+      assert_file_exist 'tmpdatadir'
+    ensure
+      chmod "+x", 'tmpdatadir'
+    end
+  end
+
   def test_rmdir
     check_singleton :rmdir
 


### PR DESCRIPTION
This is one idea to fix #57.

I think this is a bug, so I didn't care about backwards compatibility. In my opinion, any code forcefully removing a folder expects the folder to be removed, and if not, it will fail later on, like it happened in `bundler`.