### PR TITLE
Reenable Windows CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,4 +18,3 @@ jobs:
       run: bundle install
     - name: Run test
       run: rake
-      continue-on-error: true # test_fileutils.rb:424 and test_fileutils.rb:455


### PR DESCRIPTION
If these tests fail under the ruby-core setup, I think they should be skipped one by one instead of ignoring the whole CI in order to prevent regressions.

Context: In #58 I made a typo that only affected Windows, and CI didn't catch it because it was disabled.