### PR TITLE
Revert "FileUtils.rm* methods swallows only Errno::ENOENT when force is true"

### DIFF
--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -1165,7 +1165,7 @@ module FileUtils
   #
   # Keyword arguments:
   #
-  # - <tt>force: true</tt> - ignores raised exceptions of Errno::ENOENT
+  # - <tt>force: true</tt> - ignores raised exceptions of StandardError
   #   and its descendants.
   # - <tt>noop: true</tt> - does not remove files; returns +nil+.
   # - <tt>verbose: true</tt> - prints an equivalent command:
@@ -1248,7 +1248,7 @@ module FileUtils
   #
   # Keyword arguments:
   #
-  # - <tt>force: true</tt> - ignores raised exceptions of Errno::ENOENT
+  # - <tt>force: true</tt> - ignores raised exceptions of StandardError
   #   and its descendants.
   # - <tt>noop: true</tt> - does not remove entries; returns +nil+.
   # - <tt>secure: true</tt> - removes +src+ securely;
@@ -1315,7 +1315,7 @@ module FileUtils
   # see {Avoiding the TOCTTOU Vulnerability}[rdoc-ref:FileUtils@Avoiding+the+TOCTTOU+Vulnerability].
   #
   # Optional argument +force+ specifies whether to ignore
-  # raised exceptions of Errno::ENOENT and its descendants.
+  # raised exceptions of StandardError and its descendants.
   #
   # Related: {methods for deleting}[rdoc-ref:FileUtils@Deleting].
   #
@@ -1384,12 +1384,10 @@ module FileUtils
         ent.remove
       rescue
         raise unless force
-        raise unless Errno::ENOENT === $!
       end
     end
   rescue
     raise unless force
-    raise unless Errno::ENOENT === $!
   end
   module_function :remove_entry_secure
 
@@ -1415,7 +1413,7 @@ module FileUtils
   # should be {interpretable as a path}[rdoc-ref:FileUtils@Path+Arguments].
   #
   # Optional argument +force+ specifies whether to ignore
-  # raised exceptions of Errno::ENOENT and its descendants.
+  # raised exceptions of StandardError and its descendants.
   #
   # Related: FileUtils.remove_entry_secure.
   #
@@ -1425,12 +1423,10 @@ module FileUtils
         ent.remove
       rescue
         raise unless force
-        raise unless Errno::ENOENT === $!
       end
     end
   rescue
     raise unless force
-    raise unless Errno::ENOENT === $!
   end
   module_function :remove_entry
 
@@ -1441,7 +1437,7 @@ module FileUtils
   # should be {interpretable as a path}[rdoc-ref:FileUtils@Path+Arguments].
   #
   # Optional argument +force+ specifies whether to ignore
-  # raised exceptions of Errno::ENOENT and its descendants.
+  # raised exceptions of StandardError and its descendants.
   #
   # Related: {methods for deleting}[rdoc-ref:FileUtils@Deleting].
   #
@@ -1449,7 +1445,6 @@ module FileUtils
     Entry_.new(path).remove_file
   rescue
     raise unless force
-    raise unless Errno::ENOENT === $!
   end
   module_function :remove_file
 
@@ -1461,7 +1456,7 @@ module FileUtils
   # should be {interpretable as a path}[rdoc-ref:FileUtils@Path+Arguments].
   #
   # Optional argument +force+ specifies whether to ignore
-  # raised exceptions of Errno::ENOENT and its descendants.
+  # raised exceptions of StandardError and its descendants.
   #
   # Related: {methods for deleting}[rdoc-ref:FileUtils@Deleting].
   #

--- a/test/fileutils/test_fileutils.rb
+++ b/test/fileutils/test_fileutils.rb
@@ -1822,26 +1822,6 @@ cd -
     assert_file_not_exist 'tmpdatadir'
   end
 
-  def test_rm_rf_no_permissions
-    check_singleton :rm_rf
-
-    return if /mswin|mingw/ =~ RUBY_PLATFORM
-
-    mkdir 'tmpdatadir'
-    touch 'tmpdatadir/tmpdata'
-    chmod "-x", 'tmpdatadir'
-
-    begin
-      assert_raise Errno::EACCES do
-        rm_rf 'tmpdatadir'
-      end
-
-      assert_file_exist 'tmpdatadir'
-    ensure
-      chmod "+x", 'tmpdatadir'
-    end
-  end
-
   def test_rmdir
     check_singleton :rmdir
 


### PR DESCRIPTION
This reverts commit fa65d676ece93a1380b9e6564efa4b4566c7a44b.

This caused some incompatibility problems in real-world cases.

* https://bugs.ruby-lang.org/issues/18784#change-98927
* https://bugs.ruby-lang.org/issues/18784#change-98967