### PR TITLE
FileUtils.remove_dir checks directory

### DIFF
--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -1491,7 +1491,8 @@ module FileUtils
   # Related: {methods for deleting}[rdoc-ref:FileUtils@Deleting].
   #
   def remove_dir(path, force = false)
-    remove_entry path, force   # FIXME?? check if it is a directory
+    raise Errno::ENOTDIR, path unless File.directory?(path)
+    remove_entry path, force
   end
   module_function :remove_dir
 

--- a/test/fileutils/test_fileutils.rb
+++ b/test/fileutils/test_fileutils.rb
@@ -1763,6 +1763,14 @@ class TestFileUtils < Test::Unit::TestCase
     assert_file_not_exist 'data/tmpdir'
   end if have_file_perm?
 
+  def test_remove_dir_with_file
+    File.write('data/tmpfile', 'dummy')
+    assert_raise(Errno::ENOTDIR) { remove_dir 'data/tmpfile' }
+    assert_file_exist 'data/tmpfile'
+  ensure
+    File.unlink('data/tmpfile') if File.exist?('data/tmpfile')
+  end
+
   def test_compare_file
     check_singleton :compare_file
     # FIXME


### PR DESCRIPTION
Ensure `FileUtils.remove_dir` is passed a directory. Add a unit test verifying that `Errno::ENOTDIR` is raised when calling `remove_dir` on a non-directory/file.

This may cause some existing "working" programs to error, but in a way that prevents users from accidentally deleting files, which seems like a safer approach than allowing the program to delete the file and continue running.

Removes [FIXME added in 2005](https://github.com/ruby/fileutils/commit/b4c3fe913b811c46b8047ce8274095087d9631ea#diff-f76dd327efaf28e3cf96422b26cd2ce702f7996c28963bc26d3f46cb29fb69ceR37-R719) by @aamine.