### PR TITLE
Skip chown tests when the target group is not assignable

### DIFF
--- a/test/fileutils/test_fileutils.rb
+++ b/test/fileutils/test_fileutils.rb
@@ -41,6 +41,32 @@ class TestFileUtils < Test::Unit::TestCase
       /mswin|mingw|bcc|emx/ !~ RUBY_PLATFORM
     end
 
+    @@assignable_groups = nil
+
+    # Filter the given group IDs down to those the current process can actually
+    # assign to a file with chown.  Some environments (e.g. user-namespace
+    # containers) report supplementary groups such as the overflow GID
+    # (65534/nobody) that the kernel refuses to chgrp to; without this the
+    # group-ownership tests would fail with EPERM instead of being skipped.
+    def assignable_groups(groups)
+      @@assignable_groups ||= {}
+      groups.select do |gid|
+        @@assignable_groups.fetch(gid) do
+          Dir.mktmpdir("fileutils") do |dir|
+            probe = File.join(dir, "probe")
+            File.write(probe, "")
+            @@assignable_groups[gid] =
+              begin
+                File.chown(nil, gid, probe)
+                true
+              rescue Errno::EPERM
+                false
+              end
+          end
+        end
+      end
+    end
+
     @@have_symlink = nil
 
     def have_symlink?
@@ -182,7 +208,7 @@ class TestFileUtils < Test::Unit::TestCase
 
   def setup
     @prevdir = Dir.pwd
-    @groups = [Process.gid] | Process.groups if have_file_perm?
+    @groups = assignable_groups([Process.gid] | Process.groups) if have_file_perm?
     tmproot = @tmproot = Dir.mktmpdir "fileutils"
     Dir.chdir tmproot
     my_rm_rf 'data'; mymkdir 'data'


### PR DESCRIPTION
In user-namespace environments (e.g. ChromeOS Crostini) `getgroups(2)` can
report supplementary groups such as the overflow GID 65534 (nobody) that a
non-root process cannot actually `chgrp` a file to.

`TestFileUtils#setup` builds `@groups` straight from
`[Process.gid] | Process.groups`, so the chown tests try to chgrp a file to
such a group and fail with EPERM instead of being skipped:

```
File.chown(nil, @groups[1], path)  # => Errno::EPERM
```

This filters `@groups` with a one-time capability probe down to the groups the
process can actually assign, so the affected tests skip via their existing
`return unless @groups[1]` guard when there is no usable second group. On
systems where the group is usable (or as root) the tests run exactly as before.
