### PR TITLE
Fix relative symlink target generation

### DIFF
--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -715,7 +715,7 @@ module FileUtils
   # Keyword arguments:
   #
   # - <tt>force: true</tt> - overwrites +dest+ if it exists.
-  # - <tt>relative: false</tt> - create links relative to +dest+.
+  # - <tt>relative: true</tt> - create links relative to +dest+.
   # - <tt>noop: true</tt> - does not create links.
   # - <tt>verbose: true</tt> - prints an equivalent command:
   #
@@ -783,7 +783,7 @@ module FileUtils
         n = real_ddirs.size - i
         n -= 1 unless target_directory
         link2 = fu_clean_components(*Array.new([n, 0].max, '..'), *real_sdirs[i..-1])
-        link1 = link2 if link1.size > link2.size
+        link1 = link2 if !link2.empty? and link1.size > link2.size
       end
       s = File.join(link1)
       fu_output_message [cmd, s, d].flatten.join(' ') if verbose

--- a/test/fileutils/test_fileutils.rb
+++ b/test/fileutils/test_fileutils.rb
@@ -979,6 +979,32 @@ class TestFileUtils < Test::Unit::TestCase
     end
   end if have_symlink? and !no_broken_symlink?
 
+  def test_ln_s_relative_to_symlinked_directory
+    mkdir_p 'tmp/symlink_dir/.dotfiles/zsh'
+    mkdir_p 'tmp/symlink_dir/.config'
+
+    src = File.expand_path('tmp/symlink_dir/.dotfiles/zsh')
+    dest = File.expand_path('tmp/symlink_dir/.config/zsh')
+
+    assert_output_lines(["ln -s ../.dotfiles/zsh #{dest}"]) {
+      ln_s src, dest, relative: true, verbose: true, noop: true
+    }
+
+    ln_s src, dest, relative: true
+    assert_file.symlink?(dest)
+    assert_equal '../.dotfiles/zsh', File.readlink(dest)
+
+    lnfname = File.join(dest, 'zsh')
+    assert_output_lines(["ln -s ../../.dotfiles/zsh #{lnfname}"]) {
+      ln_s src, dest, relative: true, verbose: true, noop: true
+    }
+
+    ln_s src, dest, relative: true
+    assert_file.symlink?(lnfname)
+    assert_equal '../../.dotfiles/zsh', File.readlink(lnfname)
+    assert_equal File.realpath(src), File.realpath(lnfname)
+  end if have_symlink? and !no_broken_symlink?
+
   def test_ln_s_broken_symlink
     assert_nothing_raised {
       ln_s 'symlink', 'tmp/symlink'


### PR DESCRIPTION
Fixes https://github.com/ruby/fileutils/issues/129

Fix `FileUtils.ln_s(..., relative: true)` when the destination is a symlinked directory and the correct relative target must traverse upward with `..`.

The previous realpath-shortening step could choose an empty relative target in this shape. That produced a mangled command such as an empty `ln -s` source instead of keeping the lexical `..` path.
