### PR TITLE
Remove unused fu_copy_stream0 helper

### DIFF
--- a/lib/fileutils.rb
+++ b/lib/fileutils.rb
@@ -2066,10 +2066,6 @@ module FileUtils
       def fu_windows?; false end #:nodoc:
     end
 
-    def fu_copy_stream0(src, dest, blksize = nil)   #:nodoc:
-      IO.copy_stream(src, dest)
-    end
-
     def fu_stream_blksize(*streams) #:nodoc:
       streams.each do |s|
         next unless s.respond_to?(:stat)


### PR DESCRIPTION
`FileUtils::StreamUtils_#fu_copy_stream0` is a private, undocumented helper with no callers.

Commit b26846bf replaced both of its callers with direct `IO.copy_stream` calls in 2008, but retained the wrapper itself. It has been unused ever since.

This removes the unreachable helper.

Verification: `bundle exec rake test` — 423 tests, 1,135 assertions, 0 failures.